### PR TITLE
Updating container's base image version

### DIFF
--- a/Lab_Joining_Enriching_Transforming_Streaming_Data_Amazon_Kinesis/dockerized-angular-app/Dockerfile
+++ b/Lab_Joining_Enriching_Transforming_Streaming_Data_Amazon_Kinesis/dockerized-angular-app/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04
+FROM ubuntu:20.04
 RUN apt-get update -y
 RUN apt-get install software-properties-common -y --fix-missing
 RUN apt-add-repository ppa:ansible/ansible


### PR DESCRIPTION
Solving an issue where the lab fails due to Nodejs failing to install in the docker image due to the package failing to authenticate. Latest version of Ubuntu solves this issue by being used as the base